### PR TITLE
fix bool options

### DIFF
--- a/curl/basic.go
+++ b/curl/basic.go
@@ -10,9 +10,14 @@ func NewBool(value bool) *Bool {
 }
 
 func (b *Bool) Set(value string) error {
-	v, err := strconv.ParseBool(value)
-	*b = Bool(v)
-	return err
+	if value == "" {
+		*b = true
+		return nil
+	} else {
+		v, err := strconv.ParseBool(value)
+		*b = Bool(v)
+		return err
+	}
 }
 
 func (b Bool) Get() interface{} { return bool(b) }
@@ -167,3 +172,7 @@ func formatInt64(i int64) string {
 	}
 	return strconv.FormatInt(i, 10)
 }
+
+var (
+	_ boolFlag = (*Bool)(nil)
+)

--- a/curl/option.go
+++ b/curl/option.go
@@ -27,7 +27,7 @@ type Option struct {
 }
 
 func (opt *Option) String() string {
-	if isBoolFlag(opt.Value) {
+	if IsBoolFlag(opt.Value) {
 		if on, _ := opt.Value.Get().(bool); on {
 			return opt.Name
 		}
@@ -37,8 +37,8 @@ func (opt *Option) String() string {
 	return ""
 }
 
-func isBoolFlag(v Value) bool {
-	x, _ := v.(interface{ IsBoolFlag() bool })
+func IsBoolFlag(v Value) bool {
+	x, _ := v.(boolFlag)
 	return x != nil && x.IsBoolFlag()
 }
 
@@ -46,4 +46,8 @@ type Value interface {
 	flag.Value
 	flag.Getter
 	Type() string
+}
+
+type boolFlag interface {
+	IsBoolFlag() bool
 }


### PR DESCRIPTION
This PR fixes the use of boolean options, which were forced to have a value before.

The issue came from the `pflag` package not detecting boolean values via implementation of `interface{ IsBoolFlag() bool }` like the standard `flag` package does, and instead of relying on setting the `NoOptDefVal` being assigned. 

I also improved a few usage error messages.